### PR TITLE
Fix release checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,6 @@ jobs:
     outputs:
       is_release_tag: ${{ steps.check-tag.outputs.is_release_tag }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
       - name: Check tag
         id: check-tag
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,9 +100,9 @@ jobs:
     name: Cleanup tag
     needs: [check-release-tag,create-release]
     # Run this job if:
-    # 1. The tag is a release tag and any of the previous jobs failed (also don't skip if any of the needed jobs is skipped)
+    # 1. Any of the previous jobs failed (also don't skip if any of the needed jobs is skipped)
     # 2. The workflow is cancelled
-    if: ${{ ( always() && failure() && needs.check-release-tag.outputs.is_release_tag == 'true') || cancelled() }}
+    if: ${{ ( always() && failure() ) || cancelled() }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-tags: true
 
       - name: Check tag
         id: check-tag
@@ -44,6 +42,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-tags: true
+          ref: ${{ github.ref }}
 
       - name: Version sanity check
         run: |
@@ -109,8 +108,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-tags: true
 
       - name: Delete tag
         run: |


### PR DESCRIPTION
This PR attempts to fix the [error](https://github.com/ACCESS-NRI/action-build-and-upload-conda-packages/actions/runs/14324691466/job/40147982496#step:2:56) produced within the release workflow.
The error should be related to [this issue](https://github.com/actions/checkout/issues/1467).

This PR implements the following changes:
- [x] Removed a condition within the tag deletion step to run it even if there is a failure wihtin the 'Check release tag' job (like in the error above)
- [x] Removed 'fetch-tags' when not needed and added 'ref: ...' to avoid errors in the actions/checkout action
